### PR TITLE
test: improve vitest logging

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -15,6 +15,9 @@
  */
 
 import dotenv from "dotenv";
+import { FrameworkError } from "bee-agent-framework/errors";
+import * as util from "node:util";
+import { hasProps } from "bee-agent-framework/internals/helpers/object";
 dotenv.config();
 dotenv.config({
   path: ".env.test",
@@ -23,4 +26,44 @@ dotenv.config({
 dotenv.config({
   path: ".env.test.local",
   override: true,
+});
+
+function isFrameworkErrorLike(error: unknown): error is Record<keyof FrameworkError, any> {
+  const keys = ["errors", "context", "isRetryable", "isFatal"] as (keyof FrameworkError)[];
+  return hasProps(keys)(error as Record<keyof FrameworkError, any>);
+}
+
+afterEach(() => {
+  onTestFailed((testCase) => {
+    const errors = testCase.errors ?? [];
+    for (const error of errors) {
+      if (isFrameworkErrorLike(error)) {
+        error.message = util
+          .inspect(
+            {
+              message: error.message,
+              context: error.context,
+              cause: error.cause,
+              isFatal: error.isFatal,
+              isRetryable: error.isRetryable,
+              errors: error.errors,
+            },
+            {
+              compact: false,
+              depth: Infinity,
+            },
+          )
+          .replaceAll("[Object: null prototype]", "");
+      }
+    }
+  });
+});
+
+expect.addSnapshotSerializer({
+  serialize(val: FrameworkError): string {
+    return val.explain();
+  },
+  test(val): boolean {
+    return val && val instanceof FrameworkError;
+  },
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

<!--
Please include a link to an issue in the tracker.  The issue describes the problem to be solved.  If there is no issue raised for this PR then either raise one with a summary and description of the problem or add a summary and description of the problem here
-->

Ref: #7

### Description

This PR alters Vitest logging in a way such that when there is `FrameworkError`, we print the whole error so one can see what really happened. Prior to this PR, one could only see the error message.

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/bee-community-tools/blob/main/CONTRIBUTING.md)
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [x] Tests are included <!-- Bug fixes and new features should include tests -->
- [ ] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
