### PR TITLE
fix: not stubbing env vars in unit tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -36,4 +36,6 @@ jobs:
       - name: E2E Tests
         env:
           GENAI_API_KEY: ${{ secrets.GENAI_API_KEY }}
+          IMAGE_DESC_VLLM_API: ${{ secrets.IMAGE_DESC_VLLM_API }}
+          IMAGE_DESC_MODEL_ID: ${{ secrets.IMAGE_DESC_MODEL_ID }}
         run: yarn test:e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,4 @@ jobs:
       - name: Build
         run: yarn build
       - name: Unit Tests
-        env:
-          IMAGE_DESC_VLLM_API: ${{ secrets.IMAGE_DESC_VLLM_API }}
-          IMAGE_DESC_MODEL_ID: ${{ secrets.IMAGE_DESC_MODEL_ID }}
         run: yarn test:unit

--- a/src/tools/imageDescription.test.ts
+++ b/src/tools/imageDescription.test.ts
@@ -14,19 +14,16 @@
  * limitations under the License.
  */
 
-import { getEnv } from "bee-agent-framework/internals/env";
-
 import { ImageDescriptionTool } from "@/tools/imageDescription.js";
 
-import { describe, test, expect } from "vitest";
+import { afterAll, afterEach, beforeAll, expect, describe, test, vi } from "vitest";
 import { setupServer } from "msw/node";
 import { http, HttpResponse } from "msw";
 
 const exampleDescription = "This is the image description text.";
-const vllmApiEndpoint = getEnv("IMAGE_DESC_VLLM_API");
 
 const handlers = [
-  http.post(`${vllmApiEndpoint}/v1/chat/completions`, () => {
+  http.post(`https://api.openai.com/v1/chat/completions`, () => {
     return HttpResponse.json({
       choices: [
         {
@@ -43,6 +40,9 @@ const server = setupServer(...handlers);
 
 describe("ImageDescriptionTool", () => {
   beforeAll(() => {
+    vi.stubEnv("IMAGE_DESC_VLLM_API", "https://api.openai.com");
+    vi.stubEnv("IMAGE_DESC_MODEL_ID", "llava-hf/llama3-llava-next-8b-hf");
+    vi.stubEnv("OPENAI_API_KEY", "abc123");
     server.listen();
   });
 
@@ -52,6 +52,7 @@ describe("ImageDescriptionTool", () => {
 
   afterAll(() => {
     server.close();
+    vi.unstubAllEnvs();
   });
 
   test("make a request to the vllm backend to describe an image", async () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review and complete the sections below.
-->

### Which issue(s) does this pull-request address?

[Comment on Previous Commit](https://github.com/i-am-bee/bee-community-tools/commit/10621d47edf929ce39840292f562a0e07f3938d3#commitcomment-147247879)

### Description

<!-- Provide a description of the change, pay special attention to describing any breaking changes.  The description describes the resolution to the problem described in the linked issue (or to the problem outlined in this PR). -->

This PR moves env vars from the main workflow to the e2e workflow.  Tests updated to stub env vars.

### Checklist

<!-- For completed items, change [ ] to [x]. -->

- [x] I have read the [contributor guide](https://github.com/i-am-bee/bee-community-tools/blob/main/CONTRIBUTING.md)
- [x] Linting passes: `yarn lint` or `yarn lint:fix`
- [x] Formatting is applied: `yarn format` or `yarn format:fix`
- [x] Unit tests pass: `yarn test:unit`
- [x] E2E tests pass: `yarn test:e2e`
- [x] Tests are included <!-- Bug fixes and new features should include tests -->
- [x] Documentation is changed or added
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
